### PR TITLE
Bump to v1.0.3, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Update the API URL from `https://www.toggl.com` to `https://api.track.toggl.com` [#8](https://github.com/singer-io/tap-toggl/pull/8)
+
 ## 1.0.2
   * Remove code that sets a report's start date to a max of 1 year ago [#5](https://github.com/singer-io/tap-toggl/pull/5)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-toggl',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the Toggl API',
       author='Stitch',
       url='http://github.com/singer-io/tap-toggl',


### PR DESCRIPTION
# Description of change
Bump to v1.0.3, update changelog

## 1.0.3
  * Update the API URL from `https://www.toggl.com` to `https://api.track.toggl.com` [#8](https://github.com/singer-io/tap-toggl/pull/8)

# Manual QA steps
 - See #8
 
# Risks
 - See #8
 
# Rollback steps
 - revert #8 and bump the version
