### PR TITLE
Define items type of 'tags' field

### DIFF
--- a/tap_toggl/schemas/time_entries.json
+++ b/tap_toggl/schemas/time_entries.json
@@ -114,7 +114,9 @@
         "null",
         "array"
       ],
-      "items": {}
+      "items": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description of change

Fixes 'tags' array field items type in time entries. Target Singer plugins that strictly check schema would fail if this type is not set.

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
