### PR TITLE
skipping on 410 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ state*.json
 node_modules
 generate-schema.js
 
+# IntelliJ
+.idea/

--- a/tap_toggl/toggl.py
+++ b/tap_toggl/toggl.py
@@ -76,6 +76,8 @@ class Toggl(object):
       while length > 0:
         url = self._paginate_endpoint(url, page)
         res = self._get(url)
+        if res.status == 410:
+          continue
         res = res["data"]
         length = len(res)
         logger.info('Endpoint returned {length} rows.'.format(length=length))


### PR DESCRIPTION
# Description of change
410 error codes in the Toggl documentation are recorded as `in case of 410 (Gone) - don't try this endpoint again`. I don't think it's possible to avoid hitting these endpoints but skipping the results rather than retrying is more ideal.

# Manual QA steps
None
 
# Risks
 Unknown
 
# Rollback steps
 - revert this branch
